### PR TITLE
Typo in cs.json

### DIFF
--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -583,7 +583,7 @@
   "app.homepage.acknowledgementTitle": "Poděkování",
   "app.homepage.androidApp": "Aplikace pro Android",
   "app.homepage.description": "ReCodEx - úvodní stránka",
-  "app.homepage.help": "Nápovědap",
+  "app.homepage.help": "Nápověda",
   "app.homepage.helpContent": "Pokud máte s používáním ReCodExu nějaké problémy, prosíme přečtěte si nejprve <a href=\"https://github.com/ReCodEx/wiki/wiki/User-documentation\">uživatelskou dokumentaci</a> (nyní pouze v angličtině).",
   "app.homepage.title": "ReCodEx - ReCodEx Code Examiner",
   "app.homepage.whatIsRecodex": "Co je ReCodEx?",


### PR DESCRIPTION
Fixed typo Nápovědap which should be Nápověda.

By the way, there are some english strings in cs.json. For example in `app.supplementaryFilesTable`.