### PR TITLE
Fix SSR bugs

### DIFF
--- a/src/redux/helpers/resourceManager/utils.js
+++ b/src/redux/helpers/resourceManager/utils.js
@@ -3,7 +3,7 @@
  * @module utils
  */
 
-import { didInvalidate } from './status';
+import { hasFailed, didInvalidate } from './status';
 
 /**
  * Create a simple default factory: id => "/<resourceName>/[<id>]"
@@ -25,4 +25,5 @@ export const defaultSelectorFactory = resourceName => state =>
  * @param {object}    The item
  * @return {boolean}  The item needs to be reloaded from the server
  */
-export const defaultNeedsRefetching = item => !item || didInvalidate(item);
+export const defaultNeedsRefetching = item =>
+  !item || hasFailed(item) || didInvalidate(item);

--- a/src/server.js
+++ b/src/server.js
@@ -47,6 +47,17 @@ app.set('view engine', 'ejs');
 app.use(Express.static('public'));
 app.use(cookieParser());
 
+const renderWithoutSSR = (res, renderProps) => {
+  const head = Helmet.rewind();
+  res.render('index', {
+    html: '',
+    head,
+    reduxState: 'undefined',
+    bundle,
+    style: '/style.css'
+  });
+};
+
 const renderPage = (res, store, renderProps) => {
   let html = renderToString(
     <Provider store={store}>
@@ -101,10 +112,9 @@ app.get('*', (req, res) => {
           })
           .map(load => load(renderProps.params, store.dispatch, userId));
 
-        const oldStore = Object.assign({}, store);
         Promise.all(loadAsync)
           .then(() => renderPage(res, store, renderProps))
-          .catch(() => renderPage(res, oldStore, renderProps));
+          .catch(() => renderWithoutSSR(res, renderProps));
       }
     }
   );


### PR DESCRIPTION
Sometimes some HTTP request fails when the SSR is in process. In such cases, the client had trouble recovering from this state. The easies solution is to skip SSR in that case and render everything on the client from scratch.