### PR TITLE
Add group exercises reducer

### DIFF
--- a/src/redux/modules/exercises.js
+++ b/src/redux/modules/exercises.js
@@ -8,7 +8,9 @@ import { actionTypes as supplementaryFilesActionTypes } from './supplementaryFil
 import { actionTypes as additionalFilesActionTypes } from './additionalExerciseFiles';
 
 const resourceName = 'exercises';
-const { actions, reduceActions } = factory({ resourceName });
+const { actions, reduceActions, actionTypes } = factory({ resourceName });
+
+export { actionTypes };
 
 /**
  * Actions

--- a/src/redux/modules/groupExercises.js
+++ b/src/redux/modules/groupExercises.js
@@ -1,0 +1,39 @@
+import { handleActions } from 'redux-actions';
+import { actionTypes } from './exercises';
+
+const initialState = {};
+
+const isGroupExercisesAction = ({ meta: { endpoint } }) =>
+  /^\/groups\/[a-zA-Z0-9-]+\/exercises/.test(endpoint);
+
+const extractGroupIdFromTheEndpoint = endpoint => {
+  const matches = /^\/groups\/([a-zA-Z0-9-]+)\/exercises/.exec(endpoint);
+  if (matches.length !== 1) {
+    // ???
+  }
+
+  return matches[1];
+};
+
+const reducer = handleActions(
+  {
+    [actionTypes.FETCH_MANY_FULFILLED]: (state, action) => {
+      if (!isGroupExercisesAction(action)) {
+        return state;
+      }
+
+      const groupId = extractGroupIdFromTheEndpoint(action.meta.endpoint);
+      const exerciseIds = action.payload.map(exercise => exercise.id);
+      const oldExerciseIds = state[groupId] || [];
+      const ids = [...oldExerciseIds, ...exerciseIds];
+
+      return {
+        ...state,
+        [groupId]: Array.from(new Set(ids))
+      };
+    }
+  },
+  initialState
+);
+
+export default reducer;

--- a/src/redux/reducer.js
+++ b/src/redux/reducer.js
@@ -18,6 +18,7 @@ import filesContent from './modules/filesContent';
 import groups from './modules/groups';
 import publicGroups from './modules/publicGroups';
 import groupResults from './modules/groupResults';
+import groupExercises from './modules/groupExercises';
 import instances from './modules/instances';
 import licences from './modules/licences';
 import limits from './modules/limits';
@@ -61,6 +62,7 @@ const createRecodexReducers = token => ({
   groups,
   publicGroups,
   groupResults,
+  groupExercises,
   instances,
   licences,
   limits,

--- a/test/redux/modules/groupExercises-test.js
+++ b/test/redux/modules/groupExercises-test.js
@@ -1,0 +1,97 @@
+import { expect } from 'chai';
+
+import reducer from '../../../src/redux/modules/groupExercises';
+
+const actionType = 'recodex/resource/exercises/FETCH_MANY_FULFILLED';
+
+describe('Group exercises', () => {
+  it('will return the same state if the ', () => {
+    const state = { X: ['Y'] };
+
+    const newState = reducer(state, {
+      type: actionType,
+      meta: { endpoint: '/exercises' }
+    });
+
+    expect(newState).to.eql(state);
+  });
+
+  it('will create a new list with the ID of the exercise', () => {
+    const state = {};
+    const action = {
+      type: actionType,
+      payload: [{ id: 'A' }],
+      meta: { endpoint: '/groups/X/exercises' }
+    };
+
+    const newState = reducer(state, action);
+
+    expect(newState).to.eql({ X: ['A'] });
+  });
+
+  it('will add the ID of the exercise among the list of the exercises for the group', () => {
+    const state = { X: ['A', 'B'] };
+    const action = {
+      type: actionType,
+      payload: [{ id: 'C' }],
+      meta: { endpoint: '/groups/X/exercises' }
+    };
+
+    const newState = reducer(state, action);
+
+    expect(newState).to.eql({ X: ['A', 'B', 'C'] });
+  });
+
+  it('will not add the ID of the exercise among the list of the exercises for the group if it is already there', () => {
+    const state = { X: ['A', 'B'] };
+    const action = {
+      type: actionType,
+      payload: [{ id: 'A' }],
+      meta: { endpoint: '/groups/X/exercises' }
+    };
+
+    const newState = reducer(state, action);
+
+    expect(newState).to.eql({ X: ['A', 'B'] });
+  });
+
+  it('will add the ID of the exercise among the list of the exercises for the group if it is already there but for a different group', () => {
+    const state = { X: ['A', 'B'], Y: ['A'] };
+    const action = {
+      type: actionType,
+      payload: [{ id: 'B' }],
+      meta: { endpoint: '/groups/Y/exercises' }
+    };
+
+    const newState = reducer(state, action);
+
+    expect(newState).to.eql({ X: ['A', 'B'], Y: ['A', 'B'] });
+  });
+
+  it('will extract a guid and add it to the list of exercises', () => {
+    const guid = 'c933db38-a69b-11e7-a937-00505601122b';
+    const state = { [guid]: ['A', 'B'] };
+    const action = {
+      type: actionType,
+      payload: [{ id: 'X' }],
+      meta: { endpoint: `/groups/${guid}/exercises` }
+    };
+
+    const newState = reducer(state, action);
+
+    expect(newState).to.eql({ [guid]: ['A', 'B', 'X'] });
+  });
+
+  it('will add multiple IDs at once', () => {
+    const state = { X: ['A', 'B'] };
+    const action = {
+      type: actionType,
+      payload: [{ id: 'C' }, { id: 'D' }],
+      meta: { endpoint: '/groups/X/exercises' }
+    };
+
+    const newState = reducer(state, action);
+
+    expect(newState).to.eql({ X: ['A', 'B', 'C', 'D'] });
+  });
+});


### PR DESCRIPTION
Simple reducer:

- in the subtree `state.groupExercises`
- the state is an object which has group ids as keys
- each key holds an array of exercise IDs
- there are no actions for this reducer
- it only accumulates data which are returned from the `/groups/{groupId}/exercises`