### PR TITLE
Properly save the removed state

### DIFF
--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -24,7 +24,11 @@ const getMiddleware = history => [
   storage.createMiddleware(
     engine,
     [],
-    [authActionTypes.LOGIN_SUCCESS, switchingActionTypes.REMOVE_USER]
+    [
+      authActionTypes.LOGIN_SUCCESS,
+      authActionTypes.LOGOUT,
+      switchingActionTypes.REMOVE_USER
+    ]
   )
 ];
 


### PR DESCRIPTION
After logout and an immediate refresh the state wasn't erased from the local storage.