### PR TITLE
Allow close evaluation progress & more

### DIFF
--- a/src/components/Assignments/EvaluationProgress/EvaluationProgress.js
+++ b/src/components/Assignments/EvaluationProgress/EvaluationProgress.js
@@ -39,11 +39,12 @@ class EvaluationProgress extends Component {
       completed = 0,
       skipped = 0,
       failed = 0,
-      finishProcessing
+      finishProcessing,
+      onClose
     } = this.props;
 
     return (
-      <Modal show={isOpen} backdrop="static">
+      <Modal show={isOpen} backdrop="static" onHide={onClose}>
         <Modal.Header closeButton>
           <Modal.Title>
             <FormattedMessage
@@ -130,7 +131,8 @@ EvaluationProgress.propTypes = {
   completed: PropTypes.number.isRequired,
   skipped: PropTypes.number.isRequired,
   failed: PropTypes.number.isRequired,
-  finishProcessing: PropTypes.func.isRequired
+  finishProcessing: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired
 };
 
 export default EvaluationProgress;

--- a/src/components/layout/Sidebar/sidebar.less
+++ b/src/components/layout/Sidebar/sidebar.less
@@ -1,4 +1,4 @@
 .mainSidebar {
   height: 100%;
-  overflow-y: scroll;
+  overflow-y: auto;
 }


### PR DESCRIPTION
- close websocket when finished, do not wait for component unmount
event, which can lead to leak of open socket
- show sidebar scrollbar only when needed