### PR TITLE
Green color for inline code in review comments

### DIFF
--- a/src/containers/App/recodex.css
+++ b/src/containers/App/recodex.css
@@ -326,6 +326,10 @@ code {
   white-space: pre-wrap;
 }
 
+.recodex-markdown-container code:not(pre > code) {
+  color: #072;
+}
+
 .wider-tooltip {
   width: 300px;
 }


### PR DESCRIPTION
Inline code inside review comments was black (which is a bit hard to distinguish from normal text).

With this change, the inline code is now green (same color as inline code in assignments).

Before:
![image](https://github.com/ReCodEx/web-app/assets/9487592/a1c39c16-6626-4dc9-8976-ecfeb760a93a)

After:
![image](https://github.com/ReCodEx/web-app/assets/9487592/3166e16f-bbf4-4e09-8213-6ccb64424644)
